### PR TITLE
Add an option to set default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,17 @@ First of all, you need to create a namespace for your config.
 // components/Config.tsx
 import createConfig from "react-runtime-config";
 
-export interface IConfig {
-  color: string;
+// All config values that need to be set in window
+interface MandatoryConfig {
+  backendUrl: string;
 }
+
+// All other config values
+const defaultConfig = {
+  color: "pink",
+};
+
+export type IConfig = MandoryConfig & typeof defaultConfig;
 
 export const { Config, AdminConfig } = createConfig<IConfig>({ namespace: "myapp" });
 
@@ -92,6 +100,7 @@ The fallback order is the following:
 
 - `localStorage.getItem("myapp.color")`
 - `window.myapp.color`
+- `defaultConfig.color`
 
 ## Options
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -175,13 +175,13 @@ describe("react-runtime-config", () => {
       });
     });
 
-    describe("default values", () => {
-      it("should return the default value", () => {
+    describe("default config", () => {
+      it("should return the default config value", () => {
         unset(window, "test.foo");
         const { Config } = createConfig<IConfig>({
           namespace: "test",
           storage,
-          defaultValues: { foo: "from-default" },
+          defaultConfig: { foo: "from-default" },
         });
         const children = jest.fn(() => <div />);
 
@@ -194,7 +194,7 @@ describe("react-runtime-config", () => {
         const { Config } = createConfig<IConfig>({
           namespace: "test",
           storage,
-          defaultValues: { foo: "from-default" },
+          defaultConfig: { foo: "from-default" },
         });
         const children = jest.fn(() => <div />);
 
@@ -207,7 +207,7 @@ describe("react-runtime-config", () => {
         const { Config } = createConfig<IConfig>({
           namespace: "test",
           storage,
-          defaultValues: { foo: "from-default" },
+          defaultConfig: { foo: "from-default" },
         });
         const children = jest.fn(() => <div />);
         storage.setItem("test.foo", "from-localstorage");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ export interface ConfigOptions<TConfig> {
   /**
    * Config default values
    */
-  defaultValues?: Partial<TConfig>;
+  defaultConfig?: Partial<TConfig>;
   /**
    * Storage adapter
    *
@@ -67,7 +67,7 @@ export function createConfig<TConfig>(options: ConfigOptions<TConfig>) {
    * Get a config value from storage, window or defaultValues
    */
   function getConfig<K extends Extract<keyof TConfig, string> = Extract<keyof TConfig, string>>(path: K): TConfig[K] {
-    const defaultValue = options.defaultValues && options.defaultValues[path];
+    const defaultValue = options.defaultConfig && options.defaultConfig[path];
     const storageValue = getStorageValue(path);
     const windowValue = getWindowValue(path);
 


### PR DESCRIPTION
### Summary

The idea is to add a `defaultConfig` option to permit "front-end" default config values. Indeed having any default values in `config.js` can be annoying, this file can be control by the ops and need to be up to date to have a working version of our application.

With this new `defaultConfig` I (as a front-end dev) can provide a default value, for non-mandatory config values (as a default color for example). All these values can also be override by the ops by injecting as before some values in `window.{mynamespace}` or locally if the `localOverride` is activate.

### Example of usage

```ts
// components/Config.tsx
import createConfig from "react-runtime-config";

interface MandatoryConfig {
  backend: string;
}

const defaultConfig {
  color: "pink"
}

export type IConfig = MandatoryConfig & typeof defaultConfig

export const { Config, AdminConfig } = createConfig<IConfig>({ namespace: "myapp", defaultConfig });

export default Config;
```