### PR TITLE
Add a `getAllConfig` method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+node_js:
+  - "8.12.0"
+deploy:
+  provider: npm
+  email: fabien@contiamo.com
+  api_key:
+    secure: hnb+fmx2Hf95AKlt6sMKAaJ/fgbpfsABl3yNnbXbDXzlKNBQ+mxneBwGfkQ17h5s4owdw5VsDRoFgtVmyq0fwOSGK9bugvS6IxvRuznV57AKJTXdaAf4YVLwFeiJIILsXL1x1ftucMoIro3SIrPFfz3VnFyI8nMBvffAYwNFnwE5FMj827n668zHWs5Y93p8Y75dSjHYwppFtNK4yn6sbyurzou87bixET3B/uJSwi9lt2aLTCkWU9pI01SNEJLBvUsTSUrdvszLv6L4zMV7HXpklhADbUGAIF8SXWSfkAiD1rFQlMJinTjNrPz6fdVkFThxeN8bS0ijKEfz0Gb2kaD14mVI3Bmxc/JqXSumhHkoH1CSVtrYBnyFb8AbqdwEdUHkvWp0cQjd/c2QCbO5loDiqy4IwR1cxfW/9JgOhy0eDhqg1sCWd3R/dLZQtmo9/l03kxqcQ2kg8sNysklqZLQ/Av9qPygOHIoSOHf4pzc9JnKSj54G+mQDJ1UT+urmkSr4kKkB942zhPh9cjWZrj/B8SCzG6NNJxOrO3jYaYo52+t+7uzp7h8Iz2ntXVyFBhqRdSTr6zV/xxNK90GLtlgbx3UFq70IlLatRSOLzpxkQ+HUWDwlfr0WF+30QbadeozFfE28d8OvivA1pWiHTIZUJBkQ9Y22wh6JWZ048h0=
+  on:
+    tags: true
+    repo: contiamo/react-runtime-config

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-
 - [Why](#why)
 - [How](#how)
 - [Getting started](#getting-started)
@@ -183,6 +182,6 @@ You have also access to `field.windowValue` and `field.storageValue` if you want
 
 ## Moar Power (if needed)
 
-We also expose from `createConfig` a simple `getConfig` and `setConfig`. These functions can be used standalone and do not require use of the `Config` component. This can be useful for accessing or mutating configuration values in component lifecycle hooks, or anywhere else outside of render.
+We also expose from `createConfig` a simple `getConfig`, `getAllConfig` and `setConfig`. These functions can be used standalone and do not require use of the `Config` component. This can be useful for accessing or mutating configuration values in component lifecycle hooks, or anywhere else outside of render.
 
 These functions and are exactly the same as their counterparts available inside the `Config` component, the only thing you lose is the hot config reload.

--- a/src/AdminConfig.tsx
+++ b/src/AdminConfig.tsx
@@ -105,11 +105,10 @@ export class AdminConfig<T> extends React.Component<AdminConfigProps<T> & Inject
   };
 
   /**
-   * Returns every config keys set in `window.{namespace}`
+   * Returns every config keys
    */
   private getConfigKeys = (): Array<Extract<keyof T, string>> => {
-    // `slice(0, -1)`is for removing the trailing point
-    return Object.keys(get(window, this.props.namespace.slice(0, -1))) as any;
+    return Object.keys(this.props.getAllConfig()) as any;
   };
 }
 

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -246,7 +246,10 @@ describe("react-runtime-config", () => {
     let children: jest.Mock<JSX.Element>;
 
     beforeEach(() => {
-      config = createConfig<IConfig>({ namespace: "test", storage });
+      const defaultConfig = {
+        batman: "from-default",
+      };
+      config = createConfig<IConfig & typeof defaultConfig>({ namespace: "test", storage, defaultConfig });
       children = jest.fn(() => <div />);
 
       const { AdminConfig } = config;
@@ -265,6 +268,7 @@ describe("react-runtime-config", () => {
         { path: "loulou", storageValue: null, value: "d", windowValue: "d" },
         { path: "foo", storageValue: null, value: "from-window", windowValue: "from-window" },
         { path: "aBoolean", storageValue: null, value: true, windowValue: true },
+        { path: "batman", storageValue: null, value: "from-default", windowValue: null },
       ];
       expect(children.mock.calls[0][0].fields).toEqual(expectedFields);
     });
@@ -279,6 +283,7 @@ describe("react-runtime-config", () => {
         { path: "loulou", storageValue: null, value: "d", windowValue: "d" },
         { path: "foo", storageValue: null, value: "from-window", windowValue: "from-window" },
         { path: "aBoolean", storageValue: null, value: true, windowValue: true },
+        { path: "batman", storageValue: null, value: "from-default", windowValue: null },
       ];
 
       expect(children.mock.calls[1][0].fields).toEqual(expectedFields);
@@ -304,6 +309,7 @@ describe("react-runtime-config", () => {
         { path: "loulou", storageValue: null, value: "d", windowValue: "d" },
         { path: "foo", storageValue: null, value: "from-window", windowValue: "from-window" },
         { path: "aBoolean", storageValue: null, value: true, windowValue: true },
+        { path: "batman", storageValue: null, value: "from-default", windowValue: null },
       ];
 
       expect(children.mock.calls[2][0].fields).toEqual(expectedFields);


### PR DESCRIPTION
### Summary

Just to provide an easier way to access to the configuration outside of `<AdminConfig>`. This can be useful for any people that want to inspect the config without implementing an admin config page.

Note: I remarked that we don't have `defaultConfig` in our `AdminConfig`, this is now fixed!

### Related issue

#5 
