### PR TITLE
Fix the case of empty user values submitted

### DIFF
--- a/src/AdminConfig.tsx
+++ b/src/AdminConfig.tsx
@@ -77,9 +77,11 @@ export class AdminConfig<T> extends React.Component<AdminConfigProps<T> & Inject
    * Update the store regarding the user values
    */
   private onSubmit = () => {
-    Object.entries(this.state).map(([path, value]) => {
-      this.props.setConfig(path as any, value);
-    });
+    Object.entries(this.state)
+      .filter(([, value]) => value !== undefined)
+      .map(([path, value]) => {
+        this.props.setConfig(path as any, value);
+      });
   };
 
   /**

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -315,5 +315,24 @@ describe("react-runtime-config", () => {
       expect(children.mock.calls[2][0].fields).toEqual(expectedFields);
       expect(children.mock.calls.length).toBe(3);
     });
+
+    it("should not erase values if I'm submit just after a reset", () => {
+      children.mock.calls[0][0].onFieldChange("picsou", "plop");
+      children.mock.calls[1][0].reset();
+      children.mock.calls[2][0].submit(); // This don't call another loop since all user values are undefined
+
+      const expectedFields = [
+        { path: "picsou", storageValue: null, value: "a", windowValue: "a" },
+        { path: "donald", storageValue: null, value: "b", windowValue: "b" },
+        { path: "riri", storageValue: null, value: "c", windowValue: "c" },
+        { path: "loulou", storageValue: null, value: "d", windowValue: "d" },
+        { path: "foo", storageValue: null, value: "from-window", windowValue: "from-window" },
+        { path: "aBoolean", storageValue: null, value: true, windowValue: true },
+        { path: "batman", storageValue: null, value: "from-default", windowValue: null },
+      ];
+
+      expect(children.mock.calls[2][0].fields).toEqual(expectedFields);
+      expect(children.mock.calls.length).toBe(3);
+    });
   });
 });


### PR DESCRIPTION
### Repro steps

![image](https://user-images.githubusercontent.com/1761469/45624533-dfee7500-ba8a-11e8-8399-14765496a7b7.png)

On an implementation of `AdminConfig`:
 - call `reset()`
 - call `submit()`
 -> all the localstorage values are set to `undefined` (as a string)
