### PR TITLE
Fix empty config case

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -568,4 +568,25 @@ describe("react-runtime-config", () => {
       expect(children.mock.calls.length).toBe(3);
     });
   });
+
+  describe("getAllConfig", () => {
+    it("should return all the config available", () => {
+      const { getAllConfig } = createConfig<IConfig>({ namespace: "test", storage });
+
+      expect(getAllConfig()).toEqual({
+        aBoolean: true,
+        donald: "b",
+        foo: "from-window",
+        loulou: "d",
+        picsou: "a",
+        riri: "c",
+      });
+    });
+
+    it("should return an empty config if window is undefined", () => {
+      const { getAllConfig } = createConfig<IConfig>({ namespace: "unknown", storage });
+
+      expect(getAllConfig()).toEqual({});
+    });
+  });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import React from "react";
 import AdminConfigBase, { AdminConfigProps } from "./AdminConfig";
 import ConfigBase, { ConfigProps } from "./Config";
 
+export { ConfigProps, AdminConfigProps };
+
 export interface ConfigOptions<TConfig> {
   namespace: string;
   /**
@@ -99,7 +101,7 @@ export function createConfig<TConfig>(options: ConfigOptions<TConfig>) {
    */
   function getAllConfig(): TConfig {
     // `slice(0, -1)`is for removing the trailing point
-    const windowKeys = Object.keys(get(window, injected.namespace.slice(0, -1))) as any;
+    const windowKeys = Object.keys(get(window, injected.namespace.slice(0, -1), {})) as any;
     const defaultKeys = Object.keys(options.defaultConfig || {});
 
     return uniq([...windowKeys, ...defaultKeys]).reduce((mem, key) => ({ ...mem, [key]: getConfig(key) }), {});


### PR DESCRIPTION
A very nice edge case found by @bgeron-contiamo !

If the config key is not defined in `windows` and we call `getAllConfig`, everything crash!

I've added some unit tests for this and fix this sneaky case 😄 